### PR TITLE
Remove restart from gearman role

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,4 @@
 - name: "Restart gearman"
   service: "name=gearman-job-server state=restarted"
   sudo: yes
+  ignore_errors: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,12 @@
   apt: "pkg=gearman state=present update_cache=yes cache_valid_time=3600"
   sudo: yes
 
+- name: "Populate gearman defaults"
+  template: "src=etc/default/gearman-job-server dest=/etc/default/gearman-job-server owner=root group=root"
+  notify:
+    - "Restart gearman"
+  sudo: yes
+
 - name: "Ensure that gearman is enabled"
   service: "name=gearman-job-server enabled=yes"
   sudo: yes
@@ -10,3 +16,6 @@
 - name: "Ensure that gearman is running"
   service: "name=gearman-job-server state=started"
   sudo: yes
+
+- name: "Flush handlers"
+  meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,18 +3,6 @@
   apt: "pkg=gearman state=present update_cache=yes cache_valid_time=3600"
   sudo: yes
 
-- name: "Populate gearman defaults"
-  template: "src=etc/default/gearman-job-server dest=/etc/default/gearman-job-server owner=root group=root"
-  notify:
-    - "Restart gearman"
-  sudo: yes
-
-- name: "Update gearman upstart"
-  template: "src=etc/init/gearman-job-server.conf dest=/etc/init/gearman-job-server.conf owner=root group=root"
-  notify:
-    - "Restart gearman"
-  sudo: yes
-
 - name: "Ensure that gearman is enabled"
   service: "name=gearman-job-server enabled=yes"
   sudo: yes


### PR DESCRIPTION
This role is updating the default gearman config file and upstart script, after installation.  This should not be necessary, as the first task (apt-get install) will make sure those files exist.

Need to test on upgrades to make sure this change doesn't break anything.