### PR TITLE
Support RedHat systems and remove become

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ansible-gearman
 
-An ansible role for deploying gearman
+An ansible role for deploying gearman.  
+
+Tested with Ubuntu 14.04 and CentOS 7.x.
 
 It uses the built-in queue by default. See `gearman_queue_paramaters` in `defaults/main.yml` for more details.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,12 @@
 ---
 
+# Note: become is being used here due to a bug in Ansible 2.2.0
+# https://github.com/ansible/ansible/issues/17490
+# become should be removed when 2.2.1 is out.
+
 - name: "Restart gearman"
   service:
-    name: "gearman-job-server"
+    name: "{{ gearman_service }}"
     state: "restarted"
-  become: "yes"
+  become: true
   ignore_errors: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 
-- name: "Install gearman packages"
+- name: os-specific vars
+  include_vars: "{{ansible_os_family}}.yml"
+  tags:
+      - always
+      
+- name: "Install Debian gearman packages"
   apt:
     pkg: "{{ item }}"
     state: "present"
@@ -8,21 +13,27 @@
     cache_valid_time: "3600"
     install_recommends: "no"
   with_items:
-    - "gearman-job-server"
-    - "gearman-tools"
-  become: "yes"
-
+     "{{ gearman_packages }}"
+  when: ansible_os_family == 'Debian'
+  
+- name: "Install Enterprise Linux gearman packages"
+  yum:
+    name: "{{ item }}"
+    state: "present"
+  with_items:
+   "{{ gearman_packages }}"
+  when: ansible_os_family == "RedHat"
+  
 - name: "Populate gearman defaults"
   template:
-    src: "etc/default/gearman-job-server"
-    dest: "/etc/default/gearman-job-server"
+    src: "{{ gearman_config_src }}"
+    dest: "{{ gearman_config_dest }}"
     owner: "root"
     group: "root"
   notify:
     - "Restart gearman"
-  become: "yes"
 
-- name: "Install upstart service"
+- name: "Install Gearman service"
   template:
     src: "etc/init/gearman-job-server.conf"
     dest: "/etc/init/gearman-job-server.conf"
@@ -30,14 +41,13 @@
     group: "root"
   notify:
     - "Restart gearman"
-  become: "yes"
-
+  when: ansible_os_family == "Debian"
+  
 - name: "Ensure that gearman is enabled and running"
   service:
-    name: "gearman-job-server"
+    name: "{{ gearman_service }}"
     enabled: "yes"
     state: "started"
-  become: "yes"
-
+  
 - name: "Flush handlers"
   meta: flush_handlers

--- a/templates/etc/sysconfig/gearmand
+++ b/templates/etc/sysconfig/gearmand
@@ -1,0 +1,2 @@
+### Settings for gearmand
+OPTIONS="--listen={{ gearman_bind_address }} --port={{ gearman_bind_port }} {{ gearman_queue_parameters }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,4 @@
+gearman_packages: ["gearman-job-server", "gearman-tools"]
+gearman_config_src: "etc/default/gearman-job-server"
+gearman_config_dest: "/etc/default/gearman-job-server"
+gearman_service: "gearman-job-server"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,4 @@
+gearman_packages: ["gearmand"]
+gearman_config_src: "etc/sysconfig/gearmand"
+gearman_config_dest: "/etc/sysconfig/gearmand"
+gearman_service: "gearmand"


### PR DESCRIPTION
Adding support for installation of gearman on CentOS/RedHat fixing #5 .

This role should work now on any Debian (upstart)
or RedHat (systemd) variant.

Support for Ubuntu 16.04 (systemd) not yet implemented.

Also removes the use of become, fixing #4.  Note that there is a bug in ansible 2.2.0, that prevents become from being inherited in handlers in a role, so the handler in this role still uses become.